### PR TITLE
VCST-4863: Fix workflow

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -89,7 +89,7 @@ jobs:
 
       - name: New module test build
         run: |
-          cd vc-module-new-module
+          cd vc-module-foo-bar
           vc-build Compile
 
       - name: Publish Nuget


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Low risk: only updates the CI workflow to `cd` into the correct generated module folder before running the build, with no product code changes.
> 
> **Overview**
> Fixes the GitHub Actions workflow test-build step to run `vc-build Compile` from the correct template-generated directory by changing the `cd` path from `vc-module-new-module` to `vc-module-foo-bar`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4941e13c320d8f2ee727bdf9e96b4b8e91df8479. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->